### PR TITLE
Fix library suffix for OSX

### DIFF
--- a/lib/libusb/call.rb
+++ b/lib/libusb/call.rb
@@ -23,7 +23,7 @@ module LIBUSB
   module Call
     extend FFI::Library
 
-    ext = FFI::Platform.windows? ? 'dll' : 'so'
+    ext = FFI::Platform::LIBSUFFIX
     bundled_dll = File.expand_path("../../libusb-1.0.#{ext}", __FILE__)
     ffi_lib(['libusb-1.0', bundled_dll])
 


### PR DESCRIPTION
Improper extension was being returned for OSX/Darwin,
causing an error if the LD_LIBRARY_PATH was not set.

Previously any non-windows system would attempt to use
'.so' as the library suffix, causing it to fail on Darwin,
which should be looking for '.dylib'. Fix was just to rely
on the FFI gem to detect and return the proper value and not
let this gem decide.

It's possible that this is linked to Issue #3
