### PR TITLE
Cancel USB transfers on any exceptions

### DIFF
--- a/lib/libusb/transfer.rb
+++ b/lib/libusb/transfer.rb
@@ -252,7 +252,7 @@ module LIBUSB
           @dev_handle.device.context.handle_events nil, @completion_flag
         rescue ERROR_INTERRUPTED
           next
-        rescue LIBUSB::Error
+        rescue Exception
           cancel!
           until @completion_flag.completed?
             @dev_handle.device.context.handle_events nil, @completion_flag


### PR DESCRIPTION
.. not only LIBUSB::Error, but also Interrupt or IRB::Abort, etc.

Otherwise incomplete transfers lead to LIBUSB::ERROR_BUSY at the next command.