### PR TITLE
Add reference counter for LIBUSB::Context usage

### DIFF
--- a/lib/libusb/device.rb
+++ b/lib/libusb/device.rb
@@ -29,7 +29,9 @@ module LIBUSB
       @context = context
       def pDev.unref_device(id)
         Call.libusb_unref_device(self)
+        @ctx.unref_context
       end
+      pDev.instance_variable_set(:@ctx, context.instance_variable_get(:@ctx).ref_context)
       ObjectSpace.define_finalizer(self, pDev.method(:unref_device))
       Call.libusb_ref_device(pDev)
       @pDev = pDev

--- a/lib/libusb/endpoint.rb
+++ b/lib/libusb/endpoint.rb
@@ -181,13 +181,14 @@ module LIBUSB
       # @return [SsCompanion]
       def ss_companion
         ep_comp = FFI::MemoryPointer.new :pointer
+        ctx = device.context.instance_variable_get(:@ctx)
         res = Call.libusb_get_ss_endpoint_companion_descriptor(
-          device.context.instance_variable_get(:@ctx),
+          ctx,
           pointer,
           ep_comp
         )
         LIBUSB.raise_error res, "in libusb_get_ss_endpoint_companion_descriptor" if res!=0
-        SsCompanion.new ep_comp.read_pointer
+        SsCompanion.new ctx, ep_comp.read_pointer
       end
     end
   end


### PR DESCRIPTION
The reference counter is increased on every object that is bound to a libusb context. If the context is freed before any object that is bound to a context, that the call to `libusb_exit` is postponed to the last unreferening object.

This changes several objects from FFI::ManagedStruct to FFI::Struct with manual definition of a finalizer. This is since we can not easily pass a ctx pointer to the ManagedStruct release method.

Fixes #46