### PR TITLE
Don't kill the EventMachine reactor on LIBUSB_ERROR_INTERRUPTED

### DIFF
--- a/lib/libusb/eventmachine.rb
+++ b/lib/libusb/eventmachine.rb
@@ -52,7 +52,12 @@ class Context
       # Libusb pollfd API is not available on this platform.
       # Use simple polling timer, instead:
       EventMachine.add_periodic_timer(0.01) do
-        @eventmachine_timer = self.handle_events 0
+        begin
+          @eventmachine_timer = self.handle_events 0
+        rescue ERROR_INTERRUPTED
+          # Interrupted by a signal; nothing was handled. The next tick of this
+          # periodic timer retries. See the pollfd callback below.
+        end
       end
     end
   end
@@ -98,7 +103,18 @@ class Context
         @eventmachine_timer = nil
       end
 
-      self.handle_events 0
+      begin
+        self.handle_events 0
+      rescue ERROR_INTERRUPTED
+        # poll() was interrupted by a signal, so no events were handled. This
+        # is transient and retryable: the descriptor stays watched and the next
+        # readable/writable event re-enters this callback. Without this rescue
+        # the exception unwinds out of EventMachine.run and takes the whole
+        # reactor (and typically the process) down. Same handling as the
+        # synchronous transfer path in transfer.rb.
+        next
+      end
+
       timeout = self.next_timeout
 #         puts "libusb new timeout: #{timeout.inspect}"
       if timeout

--- a/test/test_libusb_event_machine_eintr.rb
+++ b/test/test_libusb_event_machine_eintr.rb
@@ -30,6 +30,7 @@ class TestLibusbEventMachineEintr < Minitest::Test
 
   def setup
     @context = Context.new
+    skip "libusb pollfd API not available on this platform" unless @context.pollfds&.any?
   end
 
   # The callback the pollfd handler invokes must swallow ERROR_INTERRUPTED and
@@ -41,27 +42,8 @@ class TestLibusbEventMachineEintr < Minitest::Test
       raise LIBUSB::ERROR_INTERRUPTED
     end
 
-    survived = false
-    EventMachine.run do
-      @context.eventmachine_register
-      conns = @context.instance_variable_get(:@eventmachine_attached_fds)
-
-      if conns.nil? || conns.empty?
-        @context.eventmachine_unregister
-        EventMachine.stop
-        skip "no libusb pollfds on this platform"
-      end
-
-      # This is exactly what EMPollfdHandler#notify_readable does.
-      conns.each_value(&:need_handle_events)
-
-      survived = EventMachine.reactor_running?
-      @context.eventmachine_unregister
-      EventMachine.stop
-    end
-
+    assert dispatch_pollfd_events, "reactor must stay up after ERROR_INTERRUPTED"
     assert_operator interrupts, :>=, 1, "handle_events should have been called"
-    assert survived, "reactor must stay up after ERROR_INTERRUPTED"
   end
 
   # Only ERROR_INTERRUPTED is transient. Every other libusb error must still
@@ -71,23 +53,29 @@ class TestLibusbEventMachineEintr < Minitest::Test
       raise LIBUSB::ERROR_NO_DEVICE
     end
 
-    assert_raises(LIBUSB::ERROR_NO_DEVICE) do
-      EventMachine.run do
-        @context.eventmachine_register
-        conns = @context.instance_variable_get(:@eventmachine_attached_fds)
+    assert_raises(LIBUSB::ERROR_NO_DEVICE) { dispatch_pollfd_events }
+  end
 
-        if conns.nil? || conns.empty?
-          @context.eventmachine_unregister
-          EventMachine.stop
-          skip "no libusb pollfds on this platform"
-        end
+  private
 
-        begin
-          conns.each_value(&:need_handle_events)
-        ensure
-          EventMachine.stop
-        end
+  # Run the reactor, register libusb's pollfds with it and invoke the resulting
+  # callbacks exactly as EMPollfdHandler#notify_readable does. Returns whether
+  # the reactor was still running once they had been dispatched.
+  def dispatch_pollfd_events
+    reactor_alive = false
+
+    EventMachine.run do
+      @context.eventmachine_register
+
+      begin
+        @context.instance_variable_get(:@eventmachine_attached_fds).each_value(&:need_handle_events)
+        reactor_alive = EventMachine.reactor_running?
+      ensure
+        @context.eventmachine_unregister
+        EventMachine.stop
       end
     end
+
+    reactor_alive
   end
 end

--- a/test/test_libusb_event_machine_eintr.rb
+++ b/test/test_libusb_event_machine_eintr.rb
@@ -1,0 +1,93 @@
+# This file is part of Libusb for Ruby.
+#
+# Libusb for Ruby is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Libusb for Ruby is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with Libusb for Ruby.  If not, see <http://www.gnu.org/licenses/>.
+
+require "minitest/autorun"
+require "libusb"
+require "libusb/eventmachine"
+require "eventmachine"
+
+# LIBUSB_ERROR_INTERRUPTED means poll() was interrupted by a signal and no
+# events were handled. It is transient and retryable, but Context#handle_events
+# raises on it like any other negative return, and the EventMachine integration
+# used to call handle_events unrescued -- so a signal arriving at the wrong
+# moment unwound out of EventMachine.run and killed the reactor.
+#
+# These tests need no USB device: they drive the registered callback directly.
+class TestLibusbEventMachineEintr < Minitest::Test
+  include LIBUSB
+
+  def setup
+    @context = Context.new
+  end
+
+  # The callback the pollfd handler invokes must swallow ERROR_INTERRUPTED and
+  # leave the reactor running.
+  def test_pollfd_callback_survives_eintr
+    interrupts = 0
+    @context.define_singleton_method(:handle_events) do |*|
+      interrupts += 1
+      raise LIBUSB::ERROR_INTERRUPTED
+    end
+
+    survived = false
+    EventMachine.run do
+      @context.eventmachine_register
+      conns = @context.instance_variable_get(:@eventmachine_attached_fds)
+
+      if conns.nil? || conns.empty?
+        @context.eventmachine_unregister
+        EventMachine.stop
+        skip "no libusb pollfds on this platform"
+      end
+
+      # This is exactly what EMPollfdHandler#notify_readable does.
+      conns.each_value(&:need_handle_events)
+
+      survived = EventMachine.reactor_running?
+      @context.eventmachine_unregister
+      EventMachine.stop
+    end
+
+    assert_operator interrupts, :>=, 1, "handle_events should have been called"
+    assert survived, "reactor must stay up after ERROR_INTERRUPTED"
+  end
+
+  # Only ERROR_INTERRUPTED is transient. Every other libusb error must still
+  # propagate, so a real fault is not silently swallowed.
+  def test_pollfd_callback_still_raises_other_errors
+    @context.define_singleton_method(:handle_events) do |*|
+      raise LIBUSB::ERROR_NO_DEVICE
+    end
+
+    assert_raises(LIBUSB::ERROR_NO_DEVICE) do
+      EventMachine.run do
+        @context.eventmachine_register
+        conns = @context.instance_variable_get(:@eventmachine_attached_fds)
+
+        if conns.nil? || conns.empty?
+          @context.eventmachine_unregister
+          EventMachine.stop
+          skip "no libusb pollfds on this platform"
+        end
+
+        begin
+          conns.each_value(&:need_handle_events)
+        ensure
+          EventMachine.stop
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
ERROR_INTERRUPTED only means `poll()` was interrupted by a signal and no events were handled — it is transient and retryable, and `transfer.rb` already treats it that way on the synchronous path.

The EventMachine integration calls `handle_events` unrescued, and `Context#handle_events` raises on every negative return. So a signal arriving while the reactor is polling raises out of the pollfd callback, unwinds through `EventMachine.run`, and takes the reactor down. In an app that runs the reactor on its main thread, that exits the process:

```
LIBUSB::ERROR_INTERRUPTED in libusb_handle_events
  libusb/context.rb:350 in 'LIBUSB::Context#handle_events'
  libusb/eventmachine.rb:101 in 'block in Context#eventmachine_add_pollfd'
  libusb/eventmachine.rb:83 in 'block in EMPollfdHandler#need_handle_events'
  eventmachine.rb:195 in 'EventMachine.run'
```

We hit this in production on an ARM Linux box running a USB hotplug watcher: the process died and was restarted by systemd. The rate was low (once in ~30 days on the affected unit), which is what makes it awkward — rare enough to look like a mystery crash.

This rescues `ERROR_INTERRUPTED` in both dispatch paths — the pollfd callback and the periodic-timer fallback used where the pollfd API is unavailable — and lets the next event or timer tick retry. The descriptor stays watched, so no events are lost. Every other libusb error still propagates unchanged.

The tests need no USB device: they drive the registered callback directly, and assert both that `ERROR_INTERRUPTED` is survived and that other errors still raise, so this cannot silently degrade into blanket error-swallowing. Verified that they fail against unpatched master with the backtrace above and pass with the fix.
